### PR TITLE
Bugfix/Fix Camera not Tweening Intro

### DIFF
--- a/Assets/_Core/Scenes/Game.unity
+++ b/Assets/_Core/Scenes/Game.unity
@@ -610,11 +610,10 @@ GameObject:
   m_Component:
   - component: {fileID: 1074143731}
   - component: {fileID: 1074143730}
-  - component: {fileID: 1074143729}
   - component: {fileID: 1074143728}
   - component: {fileID: 1074143732}
   m_Layer: 0
-  m_Name: Main Camera
+  m_Name: GameCamera
   m_TagString: MainCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -622,13 +621,6 @@ GameObject:
   m_IsActive: 1
 --- !u!81 &1074143728
 AudioListener:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1074143727}
-  m_Enabled: 1
---- !u!124 &1074143729
-Behaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
@@ -936,7 +928,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _startCameraZoom: 1
   _introDurationInSeconds: 3
-  _cameraForIntro: {fileID: 1074143730}
+  _cameraForIntro: {fileID: 1074143732}
   _overlayImage: {fileID: 1567667248}
 --- !u!4 &1755008531
 Transform:

--- a/Assets/_Core/Scripts/Internal/EntitySystem/EntityView.cs
+++ b/Assets/_Core/Scripts/Internal/EntitySystem/EntityView.cs
@@ -3,7 +3,7 @@
 public class EntityView : MonoBaseView
 {
     public EntityModel SelfModel { get; private set; }
-    protected EntityTransform ViewDeltaTransform { get; private set; }
+    public EntityTransform ViewDeltaTransform { get; private set; }
 
     protected bool IgnoreModelTransform = false;
 
@@ -25,23 +25,11 @@ public class EntityView : MonoBaseView
 
     protected virtual void Update()
     {
-        if (ViewDeltaTransform != null && SelfModel != null)
+        if (ViewDeltaTransform != null && SelfModel != null && !IgnoreModelTransform)
         {
-            Vector3 p = transform.position;
-            Vector3 r = transform.rotation.eulerAngles;
-            Vector3 s = transform.localScale;
-
-            if(!IgnoreModelTransform)
-            {
-                p = SelfModel.Transform.Position;
-                r = SelfModel.Transform.Rotation;
-                s = SelfModel.Transform.Scale;
-            }
-
-            p += ViewDeltaTransform.Position;
-            r += ViewDeltaTransform.Rotation;
-            s += ViewDeltaTransform.Scale;
-
+            Vector3 p = SelfModel.Transform.Position + ViewDeltaTransform.Position;
+            Vector3 r = SelfModel.Transform.Rotation + ViewDeltaTransform.Rotation;
+            Vector3 s = SelfModel.Transform.Scale + ViewDeltaTransform.Scale;
 
             transform.position = p;
             transform.rotation = Quaternion.Euler(r);

--- a/Assets/_Core/Scripts/Internal/MVC/Extra/Camera/CameraView.cs
+++ b/Assets/_Core/Scripts/Internal/MVC/Extra/Camera/CameraView.cs
@@ -13,13 +13,27 @@ public class CameraView : EntityView
 
     protected override void Update()
     {
-        if(_cameraModel == null)
+        base.Update();
+
+        if(_cameraModel == null || IgnoreModelTransform)
         {
             return;
         }
 
-        base.Update();
         Camera.orthographicSize = _cameraModel.OrthographicSize;
+    }
+
+    public float GetOrthographicSize()
+    {
+        if (_cameraModel == null)
+            return 0f;
+
+        return _cameraModel.OrthographicSize;
+    }
+
+    public void SetCameraChainedToView(bool chainedToView)
+    {
+        IgnoreModelTransform = !chainedToView;
     }
 
     protected override void OnViewReady()

--- a/Assets/_Core/Scripts/Specific/Game/States/IntroState/IntroGameStateView.cs
+++ b/Assets/_Core/Scripts/Specific/Game/States/IntroState/IntroGameStateView.cs
@@ -13,7 +13,7 @@ public class IntroGameStateView : MonoBehaviourGameStateView
 
     [Header("Requirements")]
     [SerializeField]
-    private Camera _cameraForIntro;
+    private CameraView _cameraForIntro;
 
     [SerializeField]
     private Image _overlayImage;
@@ -22,15 +22,10 @@ public class IntroGameStateView : MonoBehaviourGameStateView
 
     private IntroGameState _introGameState;
 
-    protected override void Awake()
-    {
-        base.Awake();
-        _originalGameZoom = _cameraForIntro.orthographicSize;
-    }
-
     protected override void OnPreStartStateView()
     {
         _introGameState = GameState as IntroGameState;
+        _originalGameZoom = _cameraForIntro.GetOrthographicSize();
         _introGameState.IntroStateSwitchedEvent += OnIntroStateSwitchedEvent;
     }
 
@@ -58,14 +53,17 @@ public class IntroGameStateView : MonoBehaviourGameStateView
     private void DoCinematicCameraVisual()
     {
         // Camera Visual Start Setup
-        _cameraForIntro.orthographicSize = _startCameraZoom;
+        _cameraForIntro.SetCameraChainedToView(false);
+        _cameraForIntro.Camera.orthographicSize = _startCameraZoom;
         Color c = _overlayImage.color;
         c.a = 1f;
         _overlayImage.color = c;
 
         // Camera Visual Animation
-        _cameraForIntro.DOOrthoSize(_originalGameZoom, _introDurationInSeconds * 0.6f).SetEase(Ease.OutCubic).SetDelay(_introDurationInSeconds * 0.1f);
-        _overlayImage.DOFade(0f, _introDurationInSeconds).OnComplete(() => {
+        _cameraForIntro.Camera.DOOrthoSize(_originalGameZoom, _introDurationInSeconds * 0.6f).SetEase(Ease.OutCubic).SetDelay(_introDurationInSeconds * 0.1f);
+        _overlayImage.DOFade(0f, _introDurationInSeconds).OnComplete(() => 
+        {
+            _cameraForIntro.SetCameraChainedToView(true);
             _introGameState.GoToNextState();
         });
     }


### PR DESCRIPTION
Changes:
* Made it so the camera view is unchained from the model during the intro cutscene, and then reconnected. So a visual effect can be played which had nothing to do with the game mechanics