### PR TITLE
hotfix/word-ui-display-targeting-color-refresh-bug

### DIFF
--- a/Assets/_Core/Scripts/Specific/UI/WordsDisplayer/WordUIDisplayItemView.cs
+++ b/Assets/_Core/Scripts/Specific/UI/WordsDisplayer/WordUIDisplayItemView.cs
@@ -64,6 +64,7 @@ public class WordUIDisplayItemView : EntityView
 	protected override void OnViewDestroy()
 	{
 		base.OnViewDestroy();
+		ResetTextColor();
 		_wordUIDisplayItemModel.NewWordDisplayingEvent -= OnNewWordDisplayingEvent;
 		_wordUIDisplayItemModel = null;
 		_gameCamera = null;
@@ -164,7 +165,6 @@ public class WordUIDisplayItemView : EntityView
 		if(_lastTextColorApplyMethod != null)
 		{
 			_lastTextColorApplyMethod();
-			_lastTextColorApplyMethod = null;
 		}
 	}
 }

--- a/Assets/_Core/Scripts/Specific/Waves/WaveSystemModel.cs
+++ b/Assets/_Core/Scripts/Specific/Waves/WaveSystemModel.cs
@@ -123,8 +123,8 @@ public class WaveSystemModel : BaseModel
 		section.Enemies = new EnemySpawnData[]
 		{
 			new EnemySpawnData(1, "First", "Hello2"),
-			new EnemySpawnData(1, "Second", "Hello but then a bit bigger"),
-			new EnemySpawnData(2, "The Number after two", "Hello"),
+			//new EnemySpawnData(1, "Second", "Hello but then a bit bigger"),
+			//new EnemySpawnData(2, "The Number after two", "Hello"),
 		};
 
 		section.TimeToFightEnemiesInSeconds = TIME_TO_FIGHT_UNTIL_ALL_EXTINCT;


### PR DESCRIPTION
Changes:
* Removed nullification of the color change method on the completion
* Cleaned the method variable in the View destruction method.